### PR TITLE
Changes to request for authorization

### DIFF
--- a/authorization/index.md
+++ b/authorization/index.md
@@ -46,8 +46,16 @@ No matter how an app registers with ah EHR, at registration time **every SMART a
 
 ## SMART authorization and retrieval of FHIR resources: overview
 
-An app (confidential or public) can launch from within an existing EHR session ("EHR launch"), or as a standalone app.  If the app launches from an existing EHR session, the EHR context is passed along to the app as part of the launch URL.  The app later will include this context as a scope parameter when it requests authorization to access resources.   Note that the complete URLs of all apps approved for use by users of this EHR will have been registered with the EHR authorization server.
-If the app is a standalone app that launches from outside an EHR session, the app will acquire context from the EHR AS during the authorization process.  
+An app (confidential or public) can launch from within an existing EHR 
+session ("EHR launch"), or as a standalone app.  If the app launches 
+from an existing EHR session, the EHR context is passed along to the app 
+as part of the launch URL.  The app later will include this context as a 
+scope parameter when it requests authorization to access resources.   Note 
+that the complete URLs of all apps approved for use by users of this EHR 
+will have been registered with the EHR authorization server.
+
+If the app is a standalone app that launches from outside an EHR session, 
+the app will acquire context from the EHR AS during the authorization process.  
 
 In SMART's <span class="label label-primary">EHR launch</span> flow, a user has
 established an EHR session, and then decides to launch an app. This could be a
@@ -65,7 +73,16 @@ by tapping an app icon on a mobile phone home screen. This app declares its
 context requirements to the EHR's authorization server, which allows the EHR to
 gather launch context during the authorization process.
 
-Once the app is launched, it requests authorization to access a FHIR resource by redirecting its authorization request to the EHR’s authorization server.  Based on pre-defined rules and possibly end-user authorization, the EHR authorization server either grants the request by returning an authorization code to the app’s redirect URL, or denies the request.   The app then exchanges the authorization code for an access token, which the app presents to the EHR’s resource server to obtain the FHIR resource.  If a refresh token is returned along with the access token, the app may use this to request a new access token, with the same scope, once the access token expires.  
+Once the app is launched, it requests authorization to access a FHIR resource 
+by redirecting its authorization request to the EHR’s authorization server.  
+Based on pre-defined rules and possibly end-user authorization, the EHR 
+authorization server either grants the request by returning an 
+authorization code to the app’s redirect URL, or denies the request.   
+The app then exchanges the authorization code for an access token, which 
+the app presents to the EHR’s resource server to obtain the FHIR resource.  
+If a refresh token is returned along with the access token, the app may 
+use this to request a new access token, with the same scope, once 
+the access token expires.  
 
 <img class="sequence-diagram-raw"  src="http://www.websequencediagrams.com/cgi-bin/cdraw?lz=bm90ZSBsZWZ0IG9mIEFwcDogVXNlciBoYXMgbGF1bmNoZWQgYXBwXG5mcm9tIGFuIEVIUlxub3Igc3RhbmRhbG9uZSBmbG93CgBEBXJpZ2gAQApSZXF1ZXN0IGF1dGhvcml6YXRpb24KQXBwLT4-RUhSIEF1dGggU2VydmVyOiAgUmVkaXJlY3QgdG8gABkFUzogAB4Fb3JpemUAUQ8ALhEAIAkgQXBwXG4obWF5IGluY2x1ZGUgZW5kLXVzZXIAew4pAIEfFCBPbiBhcHByb3ZhbAoAgRUPLT4-AB4GAIEeDGFwcDpyAIEzB191cmw_Y29kZT0xMjMmLi4uAE0VRXhjaGFuZ2UgY29kZSBmb3IgYWNjZXNzIHRva2VuCgCCGgYAgg0SUE9TVCAvAB8FAFsJAIFxJGVudGljYXRlIGFwcACCJSBDcmVhdGUAgQMGOlxue1xuAIEVBl8AgRYFPXNlY3JldC0AgSMFLXh5eiZcbnBhdGllbnQ9NDU2JlxuZXhwaXJlc19pbjogMzYwMFxuLi4uXG59AII4EgCEZQVbAIFtDCByZXNwb25zZV0AhDcUQQCCHQYAaAcgZGF0YSB2aWEgRkhJUiBBUEkAgiwKUmVzb3VyY2UAhFAJR0VUIC9maGlyL1AAgScGLzQ1NlxuAIRSCACFEAU6IEJlYXJlciAAgVMQAIRkEwBQEVJldHVybgCBBQZyAHYIAIQVBgCEPgUAgQMPAIF2B3sAIwhUeXBlOiAiAIEWByIsICJiaXJ0aERhdGUiOi4uLn0KCgoKCgoAAQU&s=default"/>
 
@@ -200,10 +217,19 @@ URL of the EHR resource server from which the app wishes to retrieve a FHIR reso
   </tbody>
 </table>
 
-The app MUST use an unpredictable value for the state parameter with at least 128 bits of entropy. The app MUST validate the value of the state parameter upon return to the redirect URL and MUST ensure that the state value is securely tied to the user’s current session (e.g., by relating the state value to a session identifier issued by the app).
-The app SHOULD limit the grants, scope, and period of time requested to the minimum necessary.   The app MAY digitally sign the request, with the EHR validating the signature.  
+The app MUST use an unpredictable value for the state parameter 
+with at least 128 bits of entropy. The app MUST validate the value 
+of the state parameter upon return to the redirect URL and MUST ensure 
+that the state value is securely tied to the user’s current session 
+(e.g., by relating the state value to a session identifier issued 
+by the app).  The app SHOULD limit the grants, scope, and period of 
+time requested to the minimum necessary.   
 
-If the app needs to authenticate the identity of the end-user, it should include two OpenID Connect scopes:  openid and profile.   When these scopes are requested, and the request is granted, the app will receive an id_token along with the access token.  For full details, see SMART launch context parameters (/authorization/scopes-and-launch-context).
+If the app needs to authenticate the identity of the end-user, it 
+should include two OpenID Connect scopes:  openid and profile.   When 
+these scopes are requested, and the request is granted, the app will 
+receive an id_token along with the access token.  For full details, 
+see [SMART launch context parameters](./scopes-and-launch-context).
 
 #### *For example*
 An app that needs demographics and observations for a single


### PR DESCRIPTION
Changed this to step 1 of the authorization-and-retrieval sequence.

Most of these changes were motivated by the risk assessment.

1)  Made `state` a "required" parameter (instead of "recommended").
Ref:  RFC6749 (10.12)
Risk Assessment Row:  10

2) Require that client validate state parameter
Ref:  RFC6749 (10.14)
Risk Assessment Row:  12

3) High entropy for state parameter
Ref: RFC6819 (4.3.5) + MITRE recommendation
Risk Assessment Row:  23

4) Added "audience" (`aud`) parameter as countermeasure for counterfeit resource server
Ref: RFC6819 (4.6.4)
Risk Assessment Row:  33

5) Added OPTION for app to sign request 
Ref:  OIDC (16.1)
Risk Assessment Row:  37

6) Incorporated OpenID into description and example
Ref:  OIDC (16.1, 16.2)
Risk Assessment Row:  37, 38