### PR TITLE
Updated link and content

### DIFF
--- a/argonaut/index.md
+++ b/argonaut/index.md
@@ -6,15 +6,15 @@ title: Argonaut Project
 # Argonaut Project
 
 The Argonaut Project's security workgroup is supporting the development of open
-specifications for end-user authorization of clinical apps, and single-sign-on
+specifications for the authorization of clinical apps, and single-sign-on
 into clinical apps. To accomplish these goals, Argonaut is working with the
 [SMART Health IT](http://smarthealthit.org) team at Boston Children's Hospital
 to produce specifications that serve four key use cases:
 
- * Clinicians running web-based apps against EHR data
- * Clinicians running mobile apps against EHR data
- * Patients running web-absed apps against a patient portal account
- * Patients running mobile apps against a portal account
+ * Clinicians using web-based apps to access FHIR resources
+ * Clinicians using mobile apps to access FHIR resources
+ * Patients using web-based apps to access FHIR resources
+ * Patients using mobile apps to access FHIR resources 
 
 # Specs and References
 
@@ -22,9 +22,9 @@ Our specs build on two key open standards:
 [OAuth 2](https://tools.ietf.org/html/rfc6749) and [OpenID
 Connect](http://openid.net/specs/openid-connect-core-1_0.html).
 
-For full details about the Argonaut Project's security workgroup, please see:
+For full details about the Argonaut Project's security work, please see:
 
- * Specification: [SMART on FHIR Auth Specification](http://docs.smarthealthit.org/authorization/)
+ * Specification: [SMART on FHIR Auth Specification](http://fhir-docs.smarthealthit.org/argonaut-dev/authorization)
  * Discussion forum: [SMART on FHIR Google Group](https://groups.google.com/forum/#!forum/smart-on-fhir)
  * Use Cases and Slides: [Argonaut Auth Folder on Google Drive](https://drive.google.com/folderview?id=0BzDLBlJ9IyUCZ0lOY3dPTWE0TDA&usp=sharing)
 


### PR DESCRIPTION
Updated link to point to the Argonaut authz profile instead of the old SMART on FHIR profiles.  
Modified wording of use case explanations.