### PR TITLE
Correct token request doc for public clients

### DIFF
--- a/authorization/index.md
+++ b/authorization/index.md
@@ -469,7 +469,7 @@ username is the app's `client_id` and the password is the app's `client_secret`
     <tr>
       <td><code>client_id</code></td>
       <td><span class="label label-info">optional</span></td>
-      <td>If present, must match the client_id found in the Authorization header.</td>
+      <td>Required for public apps. If present, must match the client_id found in the Authorization header.</td>
     </tr>
   </tbody>
 </table>

--- a/authorization/index.md
+++ b/authorization/index.md
@@ -469,7 +469,7 @@ username is the app's `client_id` and the password is the app's `client_secret`
     <tr>
       <td><code>client_id</code></td>
       <td><span class="label label-info">optional</span></td>
-      <td>Required for public apps. If present, must match the client_id found in the Authorization header.</td>
+      <td>Required for <span class="label label-primary">public apps</span>. If present, must match the client_id found in the Authorization header.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
We've had a lot of confusion about the client_id in the token request. The OAuth 2 spec states that it is [required if the app is a public application](http://tools.ietf.org/html/rfc6749#section-4.1.3), but the current SMART doc states it's optional, without qualification.

I'm not sure I'm completely satisfied with the changes - do we have an "optionally required" flag or some other way to call out that this is required for some use cases?