### PR TITLE
Title change

### DIFF
--- a/authorization/index.md
+++ b/authorization/index.md
@@ -3,7 +3,7 @@ layout: main
 title: SMART on FHIR Authorization
 ---
 
-# Authorization Guide
+# Application Authorization for FHIR Resources
 
 SMART on FHIR provides reliable, secure authorization for a variety of app
 architectures through the use of the OAuth 2.0 standard.  This Authorization


### PR DESCRIPTION
"Authorization Guide" seems too broad.  I think the title should clearly indicate the focus on "applications" attempting to access FHIR resources.  Thus my proposed change.