### PR TITLE
Remove broken link for tutorials/testing

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -15,7 +15,7 @@ the JavaScript client.
 
 ### [Building a REST App]({{site.baseurl}}tutorials/rest/)
 
-### [Testing Your SMART App Against The Public Sandbox] ({{site.baseurl}}tutorials/testing/)
+### [Testing Your SMART App Against The Public Sandbox]({{site.baseurl}}tutorials/testing/)
 
 This tutorial will walk you through the steps for testing your SMART app 
 against our public apps container from your local machine.


### PR DESCRIPTION
There was a space character ' ' between the link's label and the url placeholder - resulting in a broken link.