### PR TITLE
Remove location launch scope and launch param

### DIFF
--- a/scopes-and-launch-context/index.md
+++ b/scopes-and-launch-context/index.md
@@ -137,10 +137,9 @@ scopes:
 #### Requesting context with scopes
 
 Requested Scope | Meaning
-------|---------|-------------------
+------|----------------------------
 `launch/patient` | Need patient context at launch time (FHIR Patient resource)
 `launch/encounter` | Need encounter context at launch time (FHIR Encounter resource)
-`launch/location` | Need location context at launch time (FHIR Location resource)
 (Others)| This list can be extended by any SMART EHR if additional context is required.
 
 ### Launch context arrives with your `access_token`
@@ -166,7 +165,6 @@ Launch context parameter | Example value | Meaning
 ------|---------|-------------------
 `patient` | `"123"`| String value with a patient id, indicating that the app was launched in the context of FHIR Patient 123. If the app has any patient-level scopes, they will be scoped to Patient 123.
 `encounter` | `"123"`| String value with an encounter id, indicating that the app was launched in the context of FHIR Encounter 123.
-`location` | `"123"`| String value with a location id, indicating that the app app was launched from the phyical place corresponding to FHIR Location 123.
 `need_patient_banner` | `true` or `false` (boolean) | Boolean value indicating whether the app was launched in a UX context where a patient banner is required (when `true`) or not required (when `false`). An app receiving a value of `false` should not take up screen real estate displaying a patient banner.
 `resource` | `"MedicationPrescription/123"`| String value with a relative resource link, describing some specific resource context for the (in this case, a particular medication prescription). This is a generic mechanism to communicate to an app that a particular resource is "of interest" at launch time.
 `intent` | `"reconcile-medications"`| String value describing the intent of the application launch (see notes [below](#launch-intent))
@@ -176,6 +174,7 @@ Launch context parameter | Example value | Meaning
 #### Notes on launch context parameters
 
 <h5 id="launch-intent"><b>App Launch Intent</b> (optional)</h5>
+
 `intent`: Some SMART apps might offer more than one context or user interface
 that can be accessed during the SMART launch. The optional `intent` parameter
 in the launch context provides a mechanism for the SMART host to communicate to
@@ -206,44 +205,10 @@ host. The meaning of intents must be negotiated between the app and the host.
 SMART apps can check for the existence of this launch context parameter and
 download the JSON file referenced by the URL value, if provided.
 
-The URL should serve a "SMART Style" JSON object with one or more of the following properties:
+The URL should serve a "SMART Style" JSON object with properties describing the look and feel of the SMART host. Currently, [these property names](../experimental.md#SMART App styling properties) are experimental.
 
-```
-{
-  color_background: "#edeae3",
-  color_error: "#9e2d2d",
-  color_highlight: "#69b5ce",
-  color_modal_backdrop: "",
-  color_success: "#498e49",
-  color_text: "#303030",
-  dim_border_radius: "6px",
-  dim_font_size: "13px",
-  dim_spacing_size: "20px",
-  font_family_body: "Georgia, Times, 'Times New Roman', serif",
-  font_family_heading: "'HelveticaNeue-Light', Helvetica, Arial, 'Lucida Grande', sans-serif;"
-}
-```
-
-The URL value itself is to be considered a version key for the contents of the SMART Style JSON:
-hosts must return a new URL value in the `smart_style_url` launch context parameter if the contents
-of this JSON is changed.
-
-Style Property | Description
----------------|-------------
-`color_background` | The color used as the background of the app.
-`color_error` | The color used when UI elements need to indicate an area or item of concern or dangerous action, such as a button to be used to delete an item, or a display an error message.
-`color_highlight` | The color used when UI elements need to indicate an area or item of focus, such as a button used to submit a form, or a loading indicator.
-`color_modal_backdrop` | The color used when displaying a backdrop behind a modal dialog or window.
-`color_success` | The color used when UI elements need to indicate a positive outcome, such as a notice that an action was completed successfully.
-`color_text` | The color used for body text in the app.
-`dim_border_radius` | The base corner radius used for UI element borders (0px results in square corners).
-`dim_font_size` | The base size of body text displayed in the app.
-`dim_spacing_size` | The base dimension used to space UI elements.
-`font_family_body` | The list of typefaces to use for body text and elements.
-`font_family_heading` | The list of typefaces to use for content heading text and elements.
-
-SMART client apps that can adjust their styles should incorporate the above
-property values into their stylesheets, but are not required to do so.
+SMART client apps that can adjust their styles should incorporate the 
+[property values](experimentalstylingproperties.md) into their stylesheets, but are not required to do so.
 
 Optionally, if the client app detects a new version of the SMART Style object
 (i.e. a new URL is returned the `smart_style_url` parameter), the client can


### PR DESCRIPTION
Fixes #131

Remove location from both launch scope and launch parameter. Note that
spec already accounts for extending launch scopes/params if required.

@jmandel , @gotdan , @kpshek - who should I be asking to review/merge these PRs? 