### PR TITLE
Fixed error by removing join() on family name

### DIFF
--- a/tutorials/authorization/index.md
+++ b/tutorials/authorization/index.md
@@ -204,7 +204,7 @@ index.html
                     "Authorization": "Bearer " + accessToken
                 },
             }).done(function(pt){
-                var name = pt.name[0].given.join(" ") +" "+ pt.name[0].family.join(" ");
+                var name = pt.name[0].given.join(" ") +" "+ pt.name[0].family;
                 document.body.innerHTML += "<h3>Patient: " + name + "</h3>";
             });
         });


### PR DESCRIPTION
The browser gives an error: 

> Uncaught TypeError: pt.name[0].family.join is not a function

According to the FHIR docs, HumanName.family can only be 0 or 1 values of type string, not an array.
http://www.hl7.org/fhir/datatypes.html#HumanName