### PR TITLE
Update Oracle Cerner sandbox documentation link

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ title: SMART on FHIR
 ## Vendor Sandboxes
 * [Allscripts](https://developer.allscripts.com/)
 * [athenahealth - athenaOne](https://docs.athenahealth.com/api/)
-* [Cerner - Provider and Patient Facing Apps](https://fhir.cerner.com/millennium/dstu2/)
+* [Oracle Cerner - Provider and Patient Facing Apps](https://fhir.cerner.com/millennium/overview/)
 * [Epic Provider Facing Apps](https://uscdi.epic.com/)
 * [Epic Patient Facing Apps](https://open.epic.com/)
 * [Intersystems](https://www.intersystems.com/fhir/)


### PR DESCRIPTION
This updates the link from a DSTU2-specific location to the overview page for all of the Millennium-specific implementation documentation.

I wasn't sure of the wording "Provider and Patient Facing Apps," so I left it. Does this need to be specified? It seems some of the other vendors don't have the same distinction.