### PR TITLE
Add mock.health sandbox to Test Environments

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,6 +37,7 @@ title: SMART on FHIR
 * [SMART Bulk Data Server (no registration required)](https://bulk-data.smarthealthit.org/): Developer tool for Bulk Data clients
     * [Source Code](https://github.com/smart-on-fhir/bulk-data-server)
 * [Logica Health Sandbox](https://sandbox.logicahealth.org): Manage your own sandbox server and users over time
+* [mock.health Sandbox](https://mock.health/sandbox/smart): SMART test environment with clinically diverse synthetic patients (US Core 6.1), built on Synthea
 
 ## Vendor Sandboxes
 * [Allscripts](https://developer.allscripts.com/)

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ title: SMART on FHIR
 * [SMART Bulk Data Server (no registration required)](https://bulk-data.smarthealthit.org/): Developer tool for Bulk Data clients
     * [Source Code](https://github.com/smart-on-fhir/bulk-data-server)
 * [Logica Health Sandbox](https://sandbox.logicahealth.org): Manage your own sandbox server and users over time
-* [mock.health Sandbox](https://mock.health/sandbox/smart): SMART test environment with clinically diverse synthetic patients (US Core 6.1), built on Synthea
+* [mock.health Sandbox](https://mock.health/docs/smart): SMART test environment with clinically diverse synthetic patients (US Core 6.1), built on Synthea
 
 ## Vendor Sandboxes
 * [Allscripts](https://developer.allscripts.com/)


### PR DESCRIPTION
mock.health is a SMART on FHIR sandbox and synthetic data platform built on Synthea. It provides clinically diverse synthetic patients with US Core 6.1 profiles for SMART app testing.

- Docs: https://mock.health/docs/smart
- Site: https://mock.health